### PR TITLE
Limit screen-awake and screensaver to the running screen

### DIFF
--- a/Pylo/ContentView.swift
+++ b/Pylo/ContentView.swift
@@ -299,7 +299,9 @@ struct ContentView: View {
   private func resetDimTimer() {
     dimTask?.cancel()
     isScreenDimmed = false
-    guard viewModel.isRunning, viewModel.keepScreenAwake, viewModel.screenSaverEnabled else {
+    guard viewModel.isRunning, viewModel.hasPairings, viewModel.keepScreenAwake,
+      viewModel.screenSaverEnabled
+    else {
       return
     }
     dimTask = Task {

--- a/Pylo/HAPViewModel.swift
+++ b/Pylo/HAPViewModel.swift
@@ -111,7 +111,7 @@ final class HAPViewModel {
     didSet {
       guard !isRestoring, keepScreenAwake != oldValue else { return }
       UserDefaults.standard.set(keepScreenAwake, forKey: "keepScreenAwake")
-      UIApplication.shared.isIdleTimerDisabled = keepScreenAwake && isRunning && hasPairings
+      updateIdleTimer()
     }
   }
   var screenSaverEnabled: Bool = false {
@@ -317,9 +317,7 @@ final class HAPViewModel {
         UserDefaults.standard.set(isPaired, forKey: "hasPairings")
         Task { @MainActor [weak self] in
           withAnimation { self?.hasPairings = isPaired }
-          if let self {
-            UIApplication.shared.isIdleTimerDisabled = self.keepScreenAwake && self.isRunning && isPaired
-          }
+          self?.updateIdleTimer()
         }
       }
 
@@ -367,8 +365,12 @@ final class HAPViewModel {
       if config.motionEnabled {
         setup.motionMonitor.start()
       }
-      UIApplication.shared.isIdleTimerDisabled = self.keepScreenAwake && self.hasPairings
+      updateIdleTimer()
     }
+  }
+
+  func updateIdleTimer() {
+    UIApplication.shared.isIdleTimerDisabled = keepScreenAwake && isRunning && hasPairings
   }
 
   @MainActor


### PR DESCRIPTION
The idle timer and screensaver were active globally, including on the pairing screen where normal system behavior is expected. Gate both behind hasPairings so they only engage once the bridge is paired.