### PR TITLE
Reset screen saver timer on all touch interactions

### DIFF
--- a/Pylo/ContentView.swift
+++ b/Pylo/ContentView.swift
@@ -6,6 +6,7 @@ struct ContentView: View {
   @State private var showUnpairConfirmation = false
   @State private var isScreenDimmed = false
   @State private var dimTask: Task<Void, Never>?
+  @State private var isDimTimerResetPending = false
 
   var body: some View {
     ZStack {
@@ -60,7 +61,12 @@ struct ContentView: View {
       .navigationViewStyle(.stack)
       .simultaneousGesture(
         DragGesture(minimumDistance: 0)
-          .onChanged { _ in resetDimTimer() }
+          .onChanged { _ in
+            guard !isDimTimerResetPending else { return }
+            isDimTimerResetPending = true
+            resetDimTimer()
+          }
+          .onEnded { _ in isDimTimerResetPending = false }
       )
       .confirmationDialog(
         "Unpair",
@@ -103,6 +109,9 @@ struct ContentView: View {
         dimTask = nil
         isScreenDimmed = false
       }
+    }
+    .onChange(of: viewModel.keepScreenAwake) { _ in
+      resetDimTimer()
     }
     .onChange(of: viewModel.screenSaverEnabled) { _ in
       if viewModel.isRunning { resetDimTimer() }


### PR DESCRIPTION
The dim timer was only reset by specific onChange handlers, so normal interactions like scrolling or tapping buttons didn't prevent the screen saver from activating. Add a simultaneous drag gesture on the navigation view to catch all touches and reset the timer.