### PR TITLE
Re-sync idle timer when app returns to foreground

### DIFF
--- a/Pylo/HAPViewModel.swift
+++ b/Pylo/HAPViewModel.swift
@@ -255,6 +255,8 @@ final class HAPViewModel: ObservableObject {
       isRestoring = false
     }
 
+    updateIdleTimer()
+
     // Re-check listener state — the NWListener may have recovered from
     // .waiting (e.g. after returning from background) without firing the
     // stateUpdateHandler again, leaving isNetworkDenied stuck on true.


### PR DESCRIPTION
## Summary
- Call `updateIdleTimer()` in `recheckPermissions()` (runs on every foreground transition) so the idle timer correctly reflects the `keepScreenAwake` setting
- iOS may reset idle timer behavior during background suspension, causing the screen to stay awake even when the Display toggle is off

## Test plan
- [ ] Toggle Display ON, background the app, foreground — screen should stay awake
- [ ] Toggle Display OFF, background the app, foreground — screen should auto-lock per system timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)