### PR TITLE
Fix concurrent crash when multiple devices interact with stream session

### DIFF
--- a/Pylo/HAPCameraAccessory+Streaming.swift
+++ b/Pylo/HAPCameraAccessory+Streaming.swift
@@ -293,7 +293,7 @@ extension HAPCameraAccessory {
       microphoneEnabled: microphoneEnabled)
     if !started {
       logger.error("Stream session failed to start — clearing session")
-      clearStreamSession()
+      clearStreamSession(ifIdenticalTo: session)
       onMonitoringCaptureNeeded?(true, nil)
     }
     onStateChange?(

--- a/Pylo/HAPCameraAccessory+Streaming.swift
+++ b/Pylo/HAPCameraAccessory+Streaming.swift
@@ -13,7 +13,7 @@ extension HAPCameraAccessory {
 
   func streamingStatusTLV() -> Data {
     var b = TLV8.Builder()
-    let status: UInt8 = streamSession != nil ? 1 : 0  // 0=Available, 1=InUse, 2=Unavailable
+    let status: UInt8 = hasActiveStreamSession ? 1 : 0  // 0=Available, 1=InUse, 2=Unavailable
     b.add(0x01, byte: status)
     return b.build()
   }
@@ -80,9 +80,8 @@ extension HAPCameraAccessory {
       "SetupEndpoints: controller=\(controllerAddress):\(controllerVideoPort)/\(controllerAudioPort)"
     )
 
-    // Stop any existing stream session before creating a new one
-    streamSession?.stopStreaming()
-    streamSession = nil
+    // Atomically detach any existing session to avoid racing with another device
+    detachStreamSession()?.stopStreaming()
 
     let videoSSRC = UInt32.random(in: 1...UInt32.max)
     let audioSSRC = UInt32.random(in: 1...UInt32.max)
@@ -294,7 +293,7 @@ extension HAPCameraAccessory {
       microphoneEnabled: microphoneEnabled)
     if !started {
       logger.error("Stream session failed to start — clearing session")
-      streamSession = nil
+      clearStreamSession()
       onMonitoringCaptureNeeded?(true, nil)
     }
     onStateChange?(
@@ -305,14 +304,15 @@ extension HAPCameraAccessory {
     // Hand off the AVCaptureSession back to monitoring if recording is armed,
     // so it can resume without a cold-start.
     let recordingArmed = hksvState.withLock({ $0.recordingActive }) != 0
+    // Atomically detach the session to avoid racing with another device
+    let session = detachStreamSession()
     let handBackSession: AVCaptureSession?
     if recordingArmed {
-      handBackSession = streamSession?.handoff()
+      handBackSession = session?.handoff()
     } else {
-      streamSession?.stopStreaming()
+      session?.stopStreaming()
       handBackSession = nil
     }
-    streamSession = nil
     onStateChange?(
       aid, Self.iidStreamingStatus, .string(streamingStatusTLV().base64EncodedString()))
     // Resume monitoring capture if recording is still armed

--- a/Pylo/HAPCameraAccessory.swift
+++ b/Pylo/HAPCameraAccessory.swift
@@ -205,9 +205,12 @@ nonisolated final class HAPCameraAccessory: HAPAccessoryProtocol, HAPSnapshotPro
     }
   }
 
-  /// Atomically clears the stream session without returning it.
-  func clearStreamSession() {
-    streamState.withLock { $0.streamSession = nil }
+  /// Atomically clears the stream session only if it is the same instance as `expected`.
+  /// Prevents a stale caller from wiping a newer session installed by another device.
+  func clearStreamSession(ifIdenticalTo expected: CameraStreamSession) {
+    streamState.withLock { s in
+      if s.streamSession === expected { s.streamSession = nil }
+    }
   }
 
   /// Most recent JPEG snapshot captured during streaming (used as fallback for snapshot requests).

--- a/Pylo/HAPCameraAccessory.swift
+++ b/Pylo/HAPCameraAccessory.swift
@@ -190,6 +190,26 @@ nonisolated final class HAPCameraAccessory: HAPAccessoryProtocol, HAPSnapshotPro
     set { streamState.withLock { $0.streamSession = newValue } }
   }
 
+  /// Atomically checks whether a stream session is active (avoids TOCTOU race).
+  var hasActiveStreamSession: Bool {
+    streamState.withLock { $0.streamSession != nil }
+  }
+
+  /// Atomically detaches and returns the current stream session, setting it to nil.
+  /// This prevents two concurrent callers from both getting a non-nil session.
+  func detachStreamSession() -> CameraStreamSession? {
+    streamState.withLock { s in
+      let prev = s.streamSession
+      s.streamSession = nil
+      return prev
+    }
+  }
+
+  /// Atomically clears the stream session without returning it.
+  func clearStreamSession() {
+    streamState.withLock { $0.streamSession = nil }
+  }
+
   /// Most recent JPEG snapshot captured during streaming (used as fallback for snapshot requests).
   /// Protected by a lock because it is written from captureQueue (via onSnapshotFrame) and from
   /// a global queue (captureSnapshot), and read from the server queue.
@@ -500,12 +520,12 @@ nonisolated final class HAPCameraAccessory: HAPAccessoryProtocol, HAPSnapshotPro
       switch value {
       case .bool(let v):
         audioSettings.withLock { $0.isMuted = v }
-        streamSession?.isMuted = v
+        streamState.withLock({ $0.streamSession })?.isMuted = v
         return true
       case .int(let v):
         let muted = v != 0
         audioSettings.withLock { $0.isMuted = muted }
-        streamSession?.isMuted = muted
+        streamState.withLock({ $0.streamSession })?.isMuted = muted
         return true
       default:
         return false
@@ -514,12 +534,12 @@ nonisolated final class HAPCameraAccessory: HAPAccessoryProtocol, HAPSnapshotPro
       switch value {
       case .bool(let v):
         audioSettings.withLock { $0.speakerMuted = v }
-        streamSession?.speakerMuted = v
+        streamState.withLock({ $0.streamSession })?.speakerMuted = v
         return true
       case .int(let v):
         let muted = v != 0
         audioSettings.withLock { $0.speakerMuted = muted }
-        streamSession?.speakerMuted = muted
+        streamState.withLock({ $0.streamSession })?.speakerMuted = muted
         return true
       default:
         return false
@@ -528,7 +548,7 @@ nonisolated final class HAPCameraAccessory: HAPAccessoryProtocol, HAPSnapshotPro
       if case .int(let v) = value {
         let vol = max(0, min(100, v))
         audioSettings.withLock { $0.speakerVolume = vol }
-        streamSession?.speakerVolume = vol
+        streamState.withLock({ $0.streamSession })?.speakerVolume = vol
         return true
       }
       return false


### PR DESCRIPTION
## Summary

- Fixes a TOCTOU race condition on `streamSession` that causes a crash when two HomeKit controllers interact simultaneously (e.g. one device adjusts audio while another stops streaming)
- The `streamSession` computed property acquires/releases the lock per access, so two callers could both read a non-nil session then double-teardown it — closing UDP sockets twice and triggering use-after-free
- Adds atomic `detachStreamSession()` that nil-outs and returns the session in a single lock acquisition, guaranteeing only one caller gets the reference

Reported by tester: "Concurrent crash at the same time as another device" (iPhone SE 2nd gen, iOS 26.3.1)

## Test plan

- [ ] Pair two HomeKit controllers (e.g. two iPhones with Home.app) to the same Pylo bridge
- [ ] Start a camera live stream from one device
- [ ] While streaming, have the second device interact with the camera (open live stream, toggle mute, or stop the stream)
- [ ] Verify no crash occurs and streaming state remains consistent
- [ ] Repeat rapidly to stress the race window

🤖 Generated with [Claude Code](https://claude.com/claude-code)