### PR TITLE
Add app review request on settings dismissal

### DIFF
--- a/Pylo/HAPViewModel.swift
+++ b/Pylo/HAPViewModel.swift
@@ -1059,15 +1059,15 @@ final class HAPViewModel: ObservableObject {
       guard now - lastRequest >= oneWeekSeconds else { return }
     }
 
-    defaults.set(now, forKey: PrefKey.lastReviewRequestDate)
-
     #if os(iOS)
       if let scene = UIApplication.shared.connectedScenes
         .first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene
       {
+        defaults.set(now, forKey: PrefKey.lastReviewRequestDate)
         SKStoreReviewController.requestReview(in: scene)
       }
     #elseif os(macOS)
+      defaults.set(now, forKey: PrefKey.lastReviewRequestDate)
       SKStoreReviewController.requestReview()
     #endif
   }

--- a/Pylo/HAPViewModel.swift
+++ b/Pylo/HAPViewModel.swift
@@ -5,8 +5,8 @@ import FragmentedMP4
 import HAP
 import Locked
 import Sensors
-import Streaming
 import StoreKit
+import Streaming
 import SwiftUI
 
 #if os(iOS)
@@ -819,7 +819,8 @@ final class HAPViewModel: ObservableObject {
         if isPaired {
           UserDefaults.standard.set(true, forKey: PrefKey.needsInitialConfig)
           if UserDefaults.standard.double(forKey: PrefKey.firstPairingDate) == 0 {
-            UserDefaults.standard.set(Date().timeIntervalSince1970, forKey: PrefKey.firstPairingDate)
+            UserDefaults.standard.set(
+              Date().timeIntervalSince1970, forKey: PrefKey.firstPairingDate)
           }
         }
         Task { @MainActor in

--- a/Pylo/HAPViewModel.swift
+++ b/Pylo/HAPViewModel.swift
@@ -45,6 +45,8 @@ nonisolated enum PrefKey {
   static let recordingActive = "recordingActive"
   static let recordingAudioActive = "recordingAudioActive"
   static let selectedRecordingConfig = "selectedRecordingConfig"
+  static let firstPairingDate = "firstPairingDate"
+  static let lastReviewRequestDate = "lastReviewRequestDate"
 }
 
 // MARK: - Accessory Config Snapshot
@@ -814,6 +816,9 @@ final class HAPViewModel: ObservableObject {
         UserDefaults.standard.set(isPaired, forKey: PrefKey.hasPairings)
         if isPaired {
           UserDefaults.standard.set(true, forKey: PrefKey.needsInitialConfig)
+          if UserDefaults.standard.double(forKey: PrefKey.firstPairingDate) == 0 {
+            UserDefaults.standard.set(Date().timeIntervalSince1970, forKey: PrefKey.firstPairingDate)
+          }
         }
         Task { @MainActor in
           withAnimation {

--- a/Pylo/HAPViewModel.swift
+++ b/Pylo/HAPViewModel.swift
@@ -19,9 +19,10 @@ import SwiftUI
 
 // MARK: - Preference Keys
 
-/// Centralizes UserDefaults key strings to prevent typos. Each key is used in both
+/// Centralizes UserDefaults key strings to prevent typos. Most keys are used in both
 /// the `@Published` property's `didSet` and in `restorePreferences()` — a mismatch
-/// between the two would silently break persistence.
+/// between the two would silently break persistence. Some keys (e.g. `firstPairingDate`,
+/// `lastReviewRequestDate`) are only used directly via UserDefaults.
 nonisolated enum PrefKey {
   static let cameraEnabled = "cameraEnabled"
   static let flashlightEnabled = "flashlightEnabled"
@@ -869,6 +870,9 @@ final class HAPViewModel: ObservableObject {
       setup.server.start()
       let paired = setup.server.pairingStore.isPaired
       UserDefaults.standard.set(paired, forKey: PrefKey.hasPairings)
+      if paired, UserDefaults.standard.double(forKey: PrefKey.firstPairingDate) == 0 {
+        UserDefaults.standard.set(Date().timeIntervalSince1970, forKey: PrefKey.firstPairingDate)
+      }
       self.hasPairings = paired
       withAnimation { self.isRunning = true }
       self.isStarting = false

--- a/Pylo/HAPViewModel.swift
+++ b/Pylo/HAPViewModel.swift
@@ -6,6 +6,7 @@ import HAP
 import Locked
 import Sensors
 import Streaming
+import StoreKit
 import SwiftUI
 
 #if os(iOS)
@@ -1036,6 +1037,39 @@ final class HAPViewModel: ObservableObject {
       try? await Task.sleep(nanoseconds: 1_000_000_000)
       isButtonPressed = false
     }
+  }
+
+  // MARK: - App Review
+
+  func requestAppReviewIfEligible() {
+    let defaults = UserDefaults.standard
+    let firstPairing = defaults.double(forKey: PrefKey.firstPairingDate)
+    guard firstPairing > 0 else { return }
+
+    let now = Date().timeIntervalSince1970
+    let oneDaySeconds: TimeInterval = 86_400
+    let oneWeekSeconds: TimeInterval = 604_800
+
+    // Must be at least 1 day since first pairing
+    guard now - firstPairing >= oneDaySeconds else { return }
+
+    // Must be at least 7 days since last review request
+    let lastRequest = defaults.double(forKey: PrefKey.lastReviewRequestDate)
+    if lastRequest > 0 {
+      guard now - lastRequest >= oneWeekSeconds else { return }
+    }
+
+    defaults.set(now, forKey: PrefKey.lastReviewRequestDate)
+
+    #if os(iOS)
+      if let scene = UIApplication.shared.connectedScenes
+        .first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene
+      {
+        SKStoreReviewController.requestReview(in: scene)
+      }
+    #elseif os(macOS)
+      SKStoreReviewController.requestReview()
+    #endif
   }
 }
 

--- a/Pylo/RunningView.swift
+++ b/Pylo/RunningView.swift
@@ -98,6 +98,7 @@ struct RunningView: View {
     if viewModel.needsRestart {
       viewModel.restart()
     }
+    viewModel.requestAppReviewIfEligible()
   }
 
   // MARK: - Pixel Shift


### PR DESCRIPTION
## Summary

- Prompts for an App Store review when the user dismisses the RunningView settings sheet
- Gated by two conditions: at least 1 day since first HomeKit pairing, and at most once per 7 days
- Uses `SKStoreReviewController` which has its own system-level throttle (~3 per year)
- Two new `PrefKey` entries (`firstPairingDate`, `lastReviewRequestDate`), one new method on `HAPViewModel`, one line added to `RunningView`

## Test plan

- [ ] Pair with HomeKit, wait 1+ day, start server, open/close settings sheet — review dialog should appear
- [ ] Close and reopen settings within 7 days — no dialog
- [ ] Verify macOS and iOS builds succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)