### PR TITLE
Allow flashlight to stay on during camera streaming

### DIFF
--- a/Pylo/HAPAccessory.swift
+++ b/Pylo/HAPAccessory.swift
@@ -190,7 +190,7 @@ nonisolated final class HAPAccessory: HAPAccessoryProtocol, @unchecked Sendable 
 
   // MARK: - Torch Control
 
-  private func applyTorchState() {
+  func applyTorchState() {
     // Snapshot both values under the lock to avoid stale captures.
     let (on, level) = lightState.withLock { (state: inout LightState) -> (Bool, Float) in
       (state.isOn, state.isOn ? Float(state.brightness) / 100.0 : 0.0)

--- a/Pylo/HAPCameraAccessory+Streaming.swift
+++ b/Pylo/HAPCameraAccessory+Streaming.swift
@@ -321,6 +321,8 @@ extension HAPCameraAccessory {
       logger.error("Stream session failed to start — clearing session")
       clearStreamSession(ifIdenticalTo: session)
       onMonitoringCaptureNeeded?(true, nil)
+    } else {
+      onStreamingDidStart?()
     }
     // Notify subscribers of the updated streaming status. This is correct even after
     // a failure: clearStreamSession sets streamSession=nil, so streamingStatusTLV()

--- a/Pylo/HAPCameraAccessory+Streaming.swift
+++ b/Pylo/HAPCameraAccessory+Streaming.swift
@@ -322,7 +322,10 @@ extension HAPCameraAccessory {
       clearStreamSession(ifIdenticalTo: session)
       onMonitoringCaptureNeeded?(true, nil)
     } else {
-      onStreamingDidStart?()
+      // Dispatch on captureQueue so this runs after startRunning() completes
+      // on cold start (where startRunning is dispatched async on captureQueue).
+      let callback = onStreamingDidStart
+      session.captureQueue.async { callback?() }
     }
     // Notify subscribers of the updated streaming status. This is correct even after
     // a failure: clearStreamSession sets streamSession=nil, so streamingStatusTLV()

--- a/Pylo/HAPCameraAccessory.swift
+++ b/Pylo/HAPCameraAccessory.swift
@@ -111,6 +111,7 @@ nonisolated final class HAPCameraAccessory: HAPAccessoryProtocol, HAPSnapshotPro
     var onMonitoringCaptureNeeded: ((_ needed: Bool, _ existingSession: AVCaptureSession?) -> Void)?
     var onMonitoringSessionHandoff: (() -> AVCaptureSession?)?
     var onStreamingStart: (() -> Void)?
+    var onStreamingDidStart: (() -> Void)?
     var onVideoMotionChange: ((Bool) -> Void)?
     var onRecordingConfigChange: ((_ active: Bool) -> Void)?
     var onRecordingAudioActiveChange: ((_ active: Bool) -> Void)?
@@ -142,6 +143,10 @@ nonisolated final class HAPCameraAccessory: HAPAccessoryProtocol, HAPSnapshotPro
   var onStreamingStart: (() -> Void)? {
     get { _callbacks.withLockUnchecked { $0.onStreamingStart } }
     set { _callbacks.withLockUnchecked { $0.onStreamingStart = newValue } }
+  }
+  var onStreamingDidStart: (() -> Void)? {
+    get { _callbacks.withLockUnchecked { $0.onStreamingDidStart } }
+    set { _callbacks.withLockUnchecked { $0.onStreamingDidStart = newValue } }
   }
   var onVideoMotionChange: ((Bool) -> Void)? {
     get { _callbacks.withLockUnchecked { $0.onVideoMotionChange } }

--- a/Pylo/HAPCameraAccessory.swift
+++ b/Pylo/HAPCameraAccessory.swift
@@ -111,7 +111,7 @@ nonisolated final class HAPCameraAccessory: HAPAccessoryProtocol, HAPSnapshotPro
     var onMonitoringCaptureNeeded: ((_ needed: Bool, _ existingSession: AVCaptureSession?) -> Void)?
     var onMonitoringSessionHandoff: (() -> AVCaptureSession?)?
     var onStreamingStart: (() -> Void)?
-    var onStreamingDidStart: (() -> Void)?
+    var onStreamingDidStart: (@Sendable () -> Void)?
     var onVideoMotionChange: ((Bool) -> Void)?
     var onRecordingConfigChange: ((_ active: Bool) -> Void)?
     var onRecordingAudioActiveChange: ((_ active: Bool) -> Void)?
@@ -144,7 +144,7 @@ nonisolated final class HAPCameraAccessory: HAPAccessoryProtocol, HAPSnapshotPro
     get { _callbacks.withLockUnchecked { $0.onStreamingStart } }
     set { _callbacks.withLockUnchecked { $0.onStreamingStart = newValue } }
   }
-  var onStreamingDidStart: (() -> Void)? {
+  var onStreamingDidStart: (@Sendable () -> Void)? {
     get { _callbacks.withLockUnchecked { $0.onStreamingDidStart } }
     set { _callbacks.withLockUnchecked { $0.onStreamingDidStart = newValue } }
   }

--- a/Pylo/HAPCameraAccessory.swift
+++ b/Pylo/HAPCameraAccessory.swift
@@ -111,6 +111,7 @@ nonisolated final class HAPCameraAccessory: HAPAccessoryProtocol, HAPSnapshotPro
     var onMonitoringCaptureNeeded: ((_ needed: Bool, _ existingSession: AVCaptureSession?) -> Void)?
     var onMonitoringSessionHandoff: (() -> AVCaptureSession?)?
     var onStreamingStart: (() -> Void)?
+    /// Called on `captureQueue` after the capture session is running.
     var onStreamingDidStart: (@Sendable () -> Void)?
     var onVideoMotionChange: ((Bool) -> Void)?
     var onRecordingConfigChange: ((_ active: Bool) -> Void)?

--- a/Pylo/HAPViewModel.swift
+++ b/Pylo/HAPViewModel.swift
@@ -1492,8 +1492,8 @@ private nonisolated func createServerSetup(config: StartConfig) throws -> Server
     }
   }
 
-  // Re-apply torch state after streaming setup completes — session
-  // reconfiguration (e.g. preset change) may reset the torch mode.
+  // Re-apply torch state after the capture session is running — session
+  // reconfiguration or startRunning() may reset the torch mode.
   camera.onStreamingDidStart = { [weak lightbulb] in
     lightbulb?.applyTorchState()
   }

--- a/Pylo/HAPViewModel.swift
+++ b/Pylo/HAPViewModel.swift
@@ -1483,18 +1483,19 @@ private nonisolated func createServerSetup(config: StartConfig) throws -> Server
     }
   }
 
-  // Stop the siren when camera streaming starts — the camera's voiceChat
-  // audio session mode kills the siren's AVAudioEngine and it can't recover.
-  camera.onStreamingStart = { [weak sirenPlayer, weak siren, weak lightbulb] in
-    // Camera streaming takes over the capture device, killing the torch.
-    if lightbulb?.isOn == true {
-      lightbulb?.updateOn(false)
-    }
-    // The camera's voiceChat audio session mode kills the siren's AVAudioEngine.
+  // The camera's voiceChat audio session mode kills the siren's AVAudioEngine
+  // and it can't recover, so stop the siren before streaming starts.
+  camera.onStreamingStart = { [weak sirenPlayer, weak siren] in
     if sirenPlayer?.isPlaying == true {
       sirenPlayer?.stop()
       siren?.updateOn(false)
     }
+  }
+
+  // Re-apply torch state after streaming setup completes — session
+  // reconfiguration (e.g. preset change) may reset the torch mode.
+  camera.onStreamingDidStart = { [weak lightbulb] in
+    lightbulb?.applyTorchState()
   }
 
   // Hand off the monitoring session's AVCaptureSession to the stream session


### PR DESCRIPTION
## Summary
- Remove preemptive torch turn-off when camera streaming starts — the torch is a device-level property that coexists with an active capture session
- Add `onStreamingDidStart` callback to re-apply torch state after streaming setup, in case session reconfiguration (e.g. preset change) resets it
- Siren turn-off remains since the `.voiceChat` audio session mode conflict is unavoidable

## Test plan
- [ ] Turn on flashlight via HomeKit, then start a camera stream — verify the torch stays on
- [ ] Start a camera stream, then turn on the flashlight — verify the torch activates
- [ ] Verify the siren still stops when streaming starts

🤖 Generated with [Claude Code](https://claude.com/claude-code)