### PR TITLE
Fix settings button and shape compatibility on older iOS

### DIFF
--- a/Pylo/ContentView.swift
+++ b/Pylo/ContentView.swift
@@ -88,7 +88,7 @@ struct ContentView: View {
         }
         .frame(maxWidth: .infinity)
         .padding(12)
-        .background(.thinMaterial, in: .rect(cornerRadius: 12))
+        .background(.thinMaterial, in: RoundedRectangle(cornerRadius: 12))
         .padding(.horizontal)
         .padding(.bottom, 4)
         .transition(.move(edge: .bottom).combined(with: .opacity))

--- a/Pylo/RunningView.swift
+++ b/Pylo/RunningView.swift
@@ -14,7 +14,6 @@ struct RunningView: View {
     ZStack {
       Color.black
         .ignoresSafeArea()
-        .onTapGesture { focus = nil }
 
       if viewModel.buttonEnabled {
         buttonTile
@@ -22,6 +21,8 @@ struct RunningView: View {
           .offset(pixelOffset)
       }
     }
+    .contentShape(Rectangle())
+    .onTapGesture { focus = nil }
     .overlay(alignment: .topTrailing) {
       gearButton
         .focused($focus, equals: .gear)
@@ -90,6 +91,7 @@ struct RunningView: View {
         .foregroundStyle(.white.opacity(0.5))
         .padding(20)
     }
+    .contentShape(Rectangle())
     .buttonStyle(.plain)
     .accessibilityLabel("Settings")
   }
@@ -144,7 +146,7 @@ struct RunningConfigView: View {
               .font(.subheadline.weight(.medium))
               .frame(maxWidth: .infinity)
               .padding(12)
-              .background(.thinMaterial, in: .rect(cornerRadius: 12))
+              .background(.thinMaterial, in: RoundedRectangle(cornerRadius: 12))
               .padding(.horizontal)
               .padding(.bottom, 4)
               .transition(.move(edge: .bottom).combined(with: .opacity))


### PR DESCRIPTION
## Summary
- Move background `onTapGesture` from `Color.black` onto the outer `ZStack` so it doesn't intercept taps meant for the gear button overlay on older iOS versions where gesture priority between ZStack children and overlays was bugged
- Add `.contentShape(Rectangle())` to the gear button for a reliable tap target with `.buttonStyle(.plain)`
- Replace `.rect(cornerRadius: 12)` (iOS 17+) with `RoundedRectangle(cornerRadius: 12)` in both `RunningView` and `ContentView`

## Test plan
- [ ] Verify gear button opens settings on an older iOS device
- [ ] Verify tapping the black background still clears focus (keyboard dismissal on macOS)
- [ ] Verify "Updating Home" and "Server will restart on close" banners render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)